### PR TITLE
Return the bitcoin address

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Returns an `Array` of `UserTransaction`.
 Bitso.user_transactions.all
 ```
 
+## Get your Bitcoin deposit address
+
+Returns a `String` with your BTC deposit address
+
+```ruby
+Bitso.bitcoin_deposit_address
+```
+
 *To be continued!**
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Returns a `String` with your BTC deposit address
 Bitso.bitcoin_deposit_address
 ```
 
+## Withdraw Bitcoins
+
+Returns a `Boolean` indicating whether the withdrawal was successful or not
+
+```ruby
+Bitso.withdraw_bitcoins(amount: 1.23456789, address: "16Gcsethp9NdCt7oQaBaFS37hWX6nWafJL")
+```
+
 *To be continued!**
 
 # Tests

--- a/lib/bitso.rb
+++ b/lib/bitso.rb
@@ -62,10 +62,12 @@ module Bitso
       return response_body
     end
   end
+
   def self.bitcoin_deposit_address
     # returns the deposit address
     self.sanity_check!
-    return Bitso::Net.post('/bitcoin_deposit_address').body_str
+    address = Bitso::Net.post('/bitcoin_deposit_address')
+    return address[1..address.length-2]
   end
 
   def self.unconfirmed_user_deposits

--- a/lib/bitso.rb
+++ b/lib/bitso.rb
@@ -55,11 +55,12 @@ module Bitso
     if options[:amount].nil? || options[:address].nil?
       raise MissingConfigExeception.new("Required parameters not supplied, :amount, :address")
     end
-    response_body = Bitso::Net.post('/bitcoin_withdrawal',options).body_str
-    if response_body != 'true'
-      return JSON.parse response_body
+    response_body = Bitso::Net.post('/bitcoin_withdrawal',options)
+    if response_body != '"ok"'
+      $stderr.puts "Withdraw Bitcoins Error: " + response_body
+      return false
     else
-      return response_body
+      return true
     end
   end
 

--- a/lib/bitso.rb
+++ b/lib/bitso.rb
@@ -59,9 +59,8 @@ module Bitso
     if response_body != '"ok"'
       $stderr.puts "Withdraw Bitcoins Error: " + response_body
       return false
-    else
-      return true
     end
+    return true
   end
 
   def self.bitcoin_deposit_address


### PR DESCRIPTION
Calling `Bitso.bitcoin_deposit_address` was returning the following error:
`/Library/Ruby/Gems/2.0.0/gems/bitso-0.1.4/lib/bitso.rb:68:in `bitcoin_deposit_address': undefined method `body_str' for "\"3JJh8bGpJgrzR5kGRK5TSqki3GFmoJV3Tz\"":String (NoMethodError)`

Furthermore, the API returns a string like `"\"3JJh8bGpJgrzR5kGRK5TSqki3GFmoJV3Tz\""`, so we should really get a substring to return a string like `"3JJh8bGpJgrzR5kGRK5TSqki3GFmoJV3Tz"`
